### PR TITLE
Restore How-To instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ![Screenshot](https://github.com/sorenh/vscode-go-coverage-viewer/raw/master/screenshot.png "Screenshot")
 
+## How to use this extension
+
+1. Open the Command Panel (Mac = cmd+shift+p)
+2. Search for "Go Coverage"
+3. Select any of our available commands to use
+
 ## Features
 
 This extension adds the ability to view your go coverage results within VS Code via a simple command.


### PR DESCRIPTION
It was not obvious how to use this extension.  I restored this from the git history.